### PR TITLE
inOrder flag argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ pull(
              //limits stream to process width items at once
   pull.collect(cb)
 )
+
+pull(
+  pull.values([....]),
+  //perform an async job in parallel,
+  //and return results in the order they arrive
+  paramap(function (data, cb) {
+    asyncJob(data, cb)
+  }, null, false), // optional flag `inOrder`, default true
+  pull.collect(cb)
+)
 ```
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-module.exports = function (map, width) {
+module.exports = function (map, width, inOrder) {
+  inOrder = inOrder === undefined ? true : inOrder
   var reading = false, abort
   return function (read) {
     var i = 0, j = 0, last = 0
@@ -37,7 +38,8 @@ module.exports = function (map, width) {
           var k = i++
 
           map(data, function (err, data) {
-            seen[k] = data
+            if (inOrder) seen[k] = data
+            else seen.push(data)
             if(err) error = err
             drain()
           })

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,27 @@
-
 var pull = require('pull-stream')
 var paraMap = require('../')
 var ordered = [], unordered = [], unordered2 = []
 var test = require('tape')
 var Abortable = require('pull-abortable')
+
+test('parallel, output unordered', function (t) {
+  t.plan(1)
+  var result = []
+  pull(pull.count(100),
+
+    paraMap(function (i, cb) {
+      setTimeout(function () {
+        result.push(i)
+        cb(null, i)
+      }, (100 - i) * 10)
+    }, null, false),
+
+  pull.collect(function (err, data) {
+    console.log(err, data)
+    console.log(result)
+    t.deepEqual(data, result, 'should emit events in the order they arrive')
+  }))
+})
 
 test('paralell, but output is ordered', function (t) {
 


### PR DESCRIPTION
Option to emit results out of order. Call the async functions in parallel, and emit results in the order they arrive. I'm not sure if this kind of operator is implemented elsewhere, couldn't find something similar.