### PR TITLE
Fix errors being lost in transit.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (map, width, inOrder) {
           if(width) start()
         } else if(j >= last && ended) {
           _cb = null
-          cb(true)
+          cb(ended)
         }
       }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -170,4 +170,19 @@ test('abort calls back', function (t) {
   }))
 })
 
-
+test('abort passes along errors', function (t) {
+  var read = pull(
+    function read(abort, cb) {
+      cb(new Error('Failure'))
+    },
+    paraMap(function (data, cb) {
+      cb(null, data)
+    }),
+    function sink (read) {
+      read(null, function next (err, data) {
+        t.equal(err.message, 'Failure')
+        t.end()
+      })
+    }
+  )
+})


### PR DESCRIPTION
If a source or sink upstream from the paramap emits an error, paramap always converts that error into true, so sinks downstream from it always just stop instead of receiving the error.

My stream kept silently eating mysql errors because of this.